### PR TITLE
Allow animations to continue when again is called

### DIFF
--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -3137,6 +3137,10 @@ function procInp(dir,dontDoWin,dontModify,bak,coord) {
 		sfxCreateList = [];
 		sfxDestroyList = [];
 		
+		if(dontModify) {
+			var oldSeedsToAnimate = seedsToAnimate;
+		}
+
 		seedsToPlay_CanMove=[];
 		seedsToPlay_CantMove=[];
 		seedsToAnimate={};
@@ -3369,6 +3373,7 @@ function procInp(dir,dontDoWin,dontModify,bak,coord) {
     		if (verbose_logging) {
     			consoleCacheDump();
     		}
+			seedsToAnimate = oldSeedsToAnimate;
 			return false;
 		}
 


### PR DESCRIPTION
Required (check [ ] -> [x] all that apply):

- [ ] There is a relevant & reviewed issue in the tracker (please link it below)
- [X] I've followed all instructions that were given in the issue comments (if not, please specify below)
- [X] This PR only resolves a single issue. (Please split up bigger PRs into multiple requests where needed.)
- [X] To the best of my ability I've followed good commit hygiene, avoided fixing too many things per commit, provided good commit messages, and did basic cleaning on the commit history if needed.
- [X] I am willing and able to release this contribution under the MIT license (if not, please explain below)
- [X] I have described this PR, highlighting important files, additional changes, and what you expect would be most important to review.
- [X] If relevant, provide example projects and tests for the unit tester

https://github.com/david-pfx/PuzzleScriptNext/issues/110

Retain seedsToAnimate when processing input with dontModify=true so that animations will continue to play when again is called.